### PR TITLE
Fix missing header include causing build issues

### DIFF
--- a/src/lib/gdbmi/gdbmi_grammar.y
+++ b/src/lib/gdbmi/gdbmi_grammar.y
@@ -67,11 +67,7 @@ static char *gdbmi_unescape_cstring(char *str)
     //assert(length >= 2);
 
     for (r = 0, s = 1; s < length - 1; ++s) {
-        if (str[s] == '\\') {
-            result[r++] = str[++s];
-        } else {
-            result[r++] = str[s];
-        }
+        result[r++] = str[s];
     }
 
     result[r] = 0;

--- a/src/lib/gdbmi/gdbmi_parser.h
+++ b/src/lib/gdbmi/gdbmi_parser.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include "logging/gdbwire_result.h"
 #include "gdbmi_pt.h"
+#include "stddef.h"
 
 /// The opaque GDB/MI parser context
 struct gdbmi_parser;


### PR DESCRIPTION
The use of size_t in gdbmi_parser_push_data requires this header.

On an unrelated note, if you happen to see this can you also look into #3? I too would like to know the license for this library. Thanks!
