### PR TITLE
Fix build with 'clang -Werror=format-security -Werror=format=2'

### DIFF
--- a/src/gdbwire_logger.h
+++ b/src/gdbwire_logger.h
@@ -36,7 +36,11 @@ enum gdbwire_logger_level {
  * Any additional format arguments.
  */
 void gdbwire_logger_log(const char *file, int line,
-        enum gdbwire_logger_level level, const char *fmt, ...);
+        enum gdbwire_logger_level level, const char *fmt, ...)
+#ifdef __GNUC__
+        __attribute__((__format__(__printf__, 4, 5)))
+#endif
+        ;
 
 /* The macros intended to be used for logging */
 #define gdbwire_debug(fmt, ...)(gdbwire_logger_log(__FILE__, __LINE__, \


### PR DESCRIPTION
Clang requires arguments of a function to be properly tagged to call
vprintf-family functions with a non-literal format string.

This problem was found when compiling GNOME Builder with clang, which
uses '-Werror=format-security -Werror=format=2' automatically.

https://bugzilla.gnome.org/show_bug.cgi?id=791923

Here are messages showed when compiling gdbwire with `CC` set to `clang` and `CFLAGS` set to `-Werror=format-security -Werror=format=2`:

```
make  all-am
/bin/sh ./libtool  --tag=CC   --mode=compile clang -DHAVE_CONFIG_H -I. -I.. -I./build    -I/path/to/gdbwire/srcdir/src  -I/path/to/gdbwire/builddir/src -march=corei7 -B/home/lantw44/.local/bin -pipe -g3 -O0 -Werror=format-security -Werror=format=2 -MT src/libgdbwire_la-gdbwire_logger.lo -MD -MP -MF src/.deps/libgdbwire_la-gdbwire_logger.Tpo -c -o src/libgdbwire_la-gdbwire_logger.lo `test -f 'src/gdbwire_logger.c' || echo '../'`src/gdbwire_logger.c
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -I./build -I/path/to/gdbwire/srcdir/src -I/path/to/gdbwire/builddir/src -march=corei7 -B/home/lantw44/.local/bin -pipe -g3 -O0 -Werror=format-security -Werror=format=2 -MT src/libgdbwire_la-gdbwire_logger.lo -MD -MP -MF src/.deps/libgdbwire_la-gdbwire_logger.Tpo -c ../src/gdbwire_logger.c  -fPIC -DPIC -o src/.libs/libgdbwire_la-gdbwire_logger.o
../src/gdbwire_logger.c:26:28: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
    size = vsnprintf(0, 0, fmt, ap);
                           ^~~
../src/gdbwire_logger.c:30:37: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
    size = vsnprintf(buf, size + 1, fmt, ap);
                                    ^~~
2 errors generated.
*** Error code 1

Stop.
make[1]: stopped in /path/to/gdbwire/builddir
```